### PR TITLE
update typing to typing_extensions 

### DIFF
--- a/lic_manager.py
+++ b/lic_manager.py
@@ -1,7 +1,7 @@
 import os
 import re
 import base58
-from typing import Literal
+from typing_extensions import Literal
 from Crypto.Util.number import bytes_to_long
 from Crypto.Util.Padding import pad
 from const import LicType


### PR DESCRIPTION
```
(env) D:\Downloads\BCompare_Keygen-main>py keygen.py -u androllen -c soft.com -s 52An-Soft -n 1
Traceback (most recent call last):
  File "keygen.py", line 2, in <module>
    from lic_manager import LicenseEncoder, LicenseDecoder, check_serial
  File "D:\Downloads\BCompare_Keygen-main\lic_manager.py", line 4, in <module>
    from typing import Literal
ImportError: cannot import name 'Literal' from 'typing' (D:\Microsoft\Python\Python37\lib\typing.py)

(env) D:\Downloads\BCompare_Keygen-main>pip --version
pip 24.0 from d:\downloads\bcompare_keygen-main\env\lib\site-packages\pip (python 3.7)

(env) D:\Downloads\BCompare_Keygen-main>python -V
Python 3.7.3

```

from typing import Literal  
update to  
from typing_extensions import Literal  
is running